### PR TITLE
Fix ransomhouse parser for new React SPA frontend

### DIFF
--- a/bin/_parsers/ransomhouse.py
+++ b/bin/_parsers/ransomhouse.py
@@ -1,17 +1,20 @@
 """
-    From Template v4 - 202412827
+    ransomhouse parser — updated for React SPA frontend (2026-03)
+
+    Site moved from JSON-in-<pre> to div.cls_record HTML structure.
+
     +----------------------------------------------+
     | Description | Website | published | post URL |
     +-----------------------+-----------+----------+
-    |       X     |         |           |     X    |
+    |       X     |    X    |     X     |     X    |
     +-----------------------+-----------+----------+
     Rappel : def appender(post_title, group_name, description="", website="", published="", post_url="", country="")
 """
 
-import os,datetime,sys,re, json
+import os, datetime, sys, re
 from bs4 import BeautifulSoup
 from datetime import datetime
-from shared_utils import find_slug_by_md5, appender,extract_md5_from_filename, stdlog, errlog
+from shared_utils import appender, errlog
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -27,25 +30,48 @@ def main():
             if filename.startswith('ransomhouse-'):
                 date_format = "%d/%m/%Y"
                 desired_format = "%Y-%m-%d %H:%M:%S.%f"
-                html_doc= tmp_dir / filename
-                file=open(html_doc, 'r')
-                soup=BeautifulSoup(file,'html.parser')
-                jsonpart= soup.pre.contents 
-                data = json.loads(jsonpart[0]) 
-                for element in data['data']:
-                    title = element['header']
-                    link = element['id']
-                    url = 'zohlm7ahjwegcedoz7lrdrti7bvpofymcayotp744qhx6gjmxbuo2yid'
-                    post_url = 'http://' + url + '.onion/r/' + link
-                    website = element['url']
-                    try:
-                        date_string = element['actionDate']
-                        datetime_obj = datetime.strptime(date_string, date_format)
-                        formated_date = datetime_obj.strftime(desired_format)
-                    except:
-                        formated_date = ''
-                    description = re.sub(r'<[^>]*>', '',element['info'])
-                    appender(title, 'ransomhouse', description,website,formated_date,post_url)
+                html_doc = tmp_dir / filename
+                file = open(html_doc, 'r')
+                soup = BeautifulSoup(file, 'html.parser')
+
+                onion_host = 'zohlm7ahjwegcedoz7lrdrti7bvpofymcayotp744qhx6gjmxbuo2yid.onion'
+
+                for record in soup.find_all('div', class_='cls_record'):
+                    link_tag = record.find('a', href=True)
+                    if not link_tag:
+                        continue
+
+                    # Victim name
+                    name_div = record.find('div', class_='cls_recordTop')
+                    title = name_div.get_text(strip=True) if name_div else None
+                    if not title:
+                        continue
+
+                    # Website
+                    url_div = record.find('div', class_='cls_recordMiddle')
+                    website = url_div.get_text(strip=True) if url_div else ''
+
+                    # Post URL
+                    post_url = 'http://' + onion_host + link_tag['href']
+
+                    # Action date from bottom elements
+                    formated_date = ''
+                    for elem in record.find_all('div', class_='cls_recordBottomElement'):
+                        header = elem.find('div', class_='cls_headerSmall')
+                        if header and 'Action date' in header.get_text():
+                            date_div = elem.find_all('div')
+                            if len(date_div) > 1:
+                                try:
+                                    datetime_obj = datetime.strptime(
+                                        date_div[1].get_text(strip=True), date_format
+                                    )
+                                    formated_date = datetime_obj.strftime(desired_format)
+                                except ValueError:
+                                    pass
+                            break
+
+                    appender(title, 'ransomhouse', '', website, formated_date, post_url)
+
                 file.close()
         except Exception as e:
             errlog(f'ransomhouse: parsing fail with error {e}')


### PR DESCRIPTION
## Summary

The ransomhouse leak site rebuilt their frontend from server-rendered JSON inside `<pre>` tags to a React SPA using `div.cls_record` HTML elements.

The current parser crashes with:
```
parsing fail with error the JSON object must be str, bytes or bytearray, not Tag
```

This happens because `soup.pre.contents[0]` now returns a BeautifulSoup `Tag` object instead of a JSON string.

## Fix

Updated the parser to extract data from the new HTML structure:

- `div.cls_recordTop > p` → victim name
- `div.cls_recordMiddle > p` → website URL
- `a[href="/r/{id}"]` → post link
- `div.cls_recordBottomElement` with "Action date" → published date

Tested against a live capture — all 165 victims extracted successfully with names, URLs, dates, and post links.